### PR TITLE
Fix share widget link and add fullscreen widget page

### DIFF
--- a/app/chatbot-trial/page.tsx
+++ b/app/chatbot-trial/page.tsx
@@ -14,7 +14,7 @@ export default async function ChatbotTrialPage() {
   const snippet = `<div id="kommander-chatbot"></div>
 <script src="${baseUrl}/chatbot.js"></script>
 <script>window.initKommanderChatbot({ userId: '${userId}' });</script>`;
-  const shareUrl = `${baseUrl}/chatbot?user=${userId}`;
+  const shareUrl = `${baseUrl}/widget-full?user=${userId}`;
 
   const currentDate = format(new Date(), 'dd MMM yyyy', { locale: it });
 

--- a/app/widget-full/page.tsx
+++ b/app/widget-full/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import ChatbotWidget from '@/frontend/components/chatbot/ChatbotWidget';
+import { useSearchParams } from 'next/navigation';
+
+export default function WidgetFullPage() {
+  const params = useSearchParams();
+  const userId = params.get('user') || '';
+  return (
+    <div className="relative h-screen w-screen bg-background">
+      <ChatbotWidget userId={userId} defaultOpen />
+    </div>
+  );
+}

--- a/frontend/components/chatbot/ChatbotWidget.tsx
+++ b/frontend/components/chatbot/ChatbotWidget.tsx
@@ -15,10 +15,11 @@ import { cn } from '@/frontend/lib/utils';
 
 interface ChatbotWidgetProps {
   userId: string;
+  defaultOpen?: boolean;
 }
 
-export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
-  const [open, setOpen] = useState(false);
+export default function ChatbotWidget({ userId, defaultOpen = false }: ChatbotWidgetProps) {
+  const [open, setOpen] = useState(defaultOpen);
   const { messages, isLoading, sendMessage, addMessage } = useWidgetChat(userId);
   const [inputValue, setInputValue] = useState('');
   const viewportRef = useRef<HTMLDivElement>(null);

--- a/frontend/components/layout/AppLayout.tsx
+++ b/frontend/components/layout/AppLayout.tsx
@@ -10,7 +10,7 @@ import { usePathname } from 'next/navigation';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const showAuthElements = pathname !== '/login'; 
+  const showAuthElements = pathname !== '/login' && !pathname.startsWith('/widget-full');
 
   return (
     <div className="relative flex flex-col min-h-screen bg-background">
@@ -31,7 +31,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         </div>
       )}
       
-      <main className={`flex-1 overflow-y-auto p-6 ${showAuthElements ? 'pl-[6rem] md:pl-[6.25rem] lg:pl-[6.5rem] pr-[4rem]' : ''}`}>
+      <main className={`flex-1 overflow-y-auto ${showAuthElements ? 'p-6 pl-[6rem] md:pl-[6.25rem] lg:pl-[6.5rem] pr-[4rem]' : 'p-0'}`}>
         {children}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- update link to use new widget-full URL
- hide dashboard chrome on widget-full page
- add standalone widget-full page for sharing

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6856a081138083268190ee296261c3b1