### PR TITLE
Implement global dark mode toggle

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,8 @@
 import type { Metadata } from 'next';
 import './globals.css'; 
 import { Inter } from 'next/font/google';
-import AppLayout from '@/frontend/components/layout/AppLayout'; 
+import AppLayout from '@/frontend/components/layout/AppLayout';
+import ThemeProvider from '@/frontend/components/layout/ThemeProvider';
 import { Toaster } from "@/frontend/components/ui/toaster"; 
 import { SessionProvider } from 'next-auth/react';
 
@@ -28,8 +29,10 @@ export default function RootLayout({
       </head>
       <body className={`${inter.variable} font-body antialiased`}>
         <SessionProvider> {/* SessionProvider MUST wrap the core content for NextAuth client features */}
-          <AppLayout>{children}</AppLayout>
-          <Toaster />
+          <ThemeProvider>
+            <AppLayout>{children}</AppLayout>
+            <Toaster />
+          </ThemeProvider>
         </SessionProvider>
       </body>
     </html>

--- a/frontend/components/layout/AppLayout.tsx
+++ b/frontend/components/layout/AppLayout.tsx
@@ -4,7 +4,8 @@
 import React from 'react';
 import Sidebar from '@/frontend/components/layout/Sidebar';
 import KommanderIcon from '@/frontend/components/layout/KommanderIcon';
-import UserProfileButton from '@/frontend/components/layout/UserProfileButton'; 
+import UserProfileButton from '@/frontend/components/layout/UserProfileButton';
+import ThemeToggle from '@/frontend/components/layout/ThemeToggle';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
@@ -26,7 +27,8 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
       )}
 
       {showAuthElements && (
-        <div className="fixed right-6 top-8 z-30">
+        <div className="fixed right-6 top-8 z-30 flex items-center gap-4">
+          <ThemeToggle />
           <UserProfileButton />
         </div>
       )}

--- a/frontend/components/layout/ThemeProvider.tsx
+++ b/frontend/components/layout/ThemeProvider.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { ThemeProvider as StyledThemeProvider, createGlobalStyle } from "styled-components";
+
+export type Theme = "light" | "dark";
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined);
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+};
+
+const lightTheme = {
+  colors: {
+    background: "#F0F2F5",
+    foreground: "#1A202C",
+  },
+};
+
+const darkTheme = {
+  colors: {
+    background: "#1A202C",
+    foreground: "#F0F2F5",
+  },
+};
+
+const GlobalStyle = createGlobalStyle`
+  body {
+    transition: background-color 0.3s ease, color 0.3s ease;
+  }
+`;
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+      document.documentElement.classList.toggle("dark", stored === "dark");
+      return;
+    }
+
+    const hour = new Date().getHours();
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const night = hour >= 18 || hour < 6;
+    const initial = prefersDark || night ? "dark" : "light";
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    setTheme((prev) => {
+      const next = prev === "light" ? "dark" : "light";
+      localStorage.setItem("theme", next);
+      document.documentElement.classList.toggle("dark", next === "dark");
+      return next;
+    });
+  };
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      <StyledThemeProvider theme={theme === "light" ? lightTheme : darkTheme}>
+        <GlobalStyle />
+        {children}
+      </StyledThemeProvider>
+    </ThemeContext.Provider>
+  );
+}

--- a/frontend/components/layout/ThemeToggle.tsx
+++ b/frontend/components/layout/ThemeToggle.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import React from "react";
+import styled from "styled-components";
+import { useTheme } from "./ThemeProvider";
+
+const ThemeToggle = () => {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <StyledWrapper>
+      <label className="switch" role="switch" aria-label="Toggle dark mode">
+        <input type="checkbox" checked={isDark} onChange={toggleTheme} />
+        <span className="slider">
+          <div className="star star_1" />
+          <div className="star star_2" />
+          <div className="star star_3" />
+          <svg viewBox="0 0 16 16" className="cloud_1 cloud" aria-hidden="true">
+            <path
+              transform="matrix(.77976 0 0 .78395-299.99-418.63)"
+              fill="#fff"
+              d="m391.84 540.91c-.421-.329-.949-.524-1.523-.524-1.351 0-2.451 1.084-2.485 2.435-1.395.526-2.388 1.88-2.388 3.466 0 1.874 1.385 3.423 3.182 3.667v.034h12.73v-.006c1.775-.104 3.182-1.584 3.182-3.395 0-1.747-1.309-3.186-2.994-3.379.007-.106.011-.214.011-.322 0-2.707-2.271-4.901-5.072-4.901-2.073 0-3.856 1.202-4.643 2.925"
+            />
+          </svg>
+        </span>
+      </label>
+    </StyledWrapper>
+  );
+};
+
+const StyledWrapper = styled.div`
+  .switch {
+    font-size: 17px;
+    position: relative;
+    display: inline-block;
+    width: 4em;
+    height: 2.2em;
+    border-radius: 30px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+  }
+
+  .switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #2a2a2a;
+    transition: 0.4s;
+    border-radius: 30px;
+    overflow: hidden;
+  }
+
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 1.2em;
+    width: 1.2em;
+    border-radius: 20px;
+    left: 0.5em;
+    bottom: 0.5em;
+    transition: 0.4s;
+    transition-timing-function: cubic-bezier(0.81, -0.04, 0.38, 1.5);
+    box-shadow: inset 8px -4px 0px 0px #fff;
+  }
+
+  .switch input:checked + .slider {
+    background-color: #00a6ff;
+  }
+
+  .switch input:checked + .slider:before {
+    transform: translateX(1.8em);
+    box-shadow: inset 15px -4px 0px 15px #ffcf48;
+  }
+
+  .star {
+    background-color: #fff;
+    border-radius: 50%;
+    position: absolute;
+    width: 5px;
+    transition: all 0.4s;
+    height: 5px;
+  }
+
+  .star_1 {
+    left: 2.5em;
+    top: 0.5em;
+  }
+
+  .star_2 {
+    left: 2.2em;
+    top: 1.2em;
+  }
+
+  .star_3 {
+    left: 3em;
+    top: 0.9em;
+  }
+
+  .switch input:checked ~ .slider .star {
+    opacity: 0;
+  }
+
+  .cloud {
+    width: 3.5em;
+    position: absolute;
+    bottom: -1.4em;
+    left: -1.1em;
+    opacity: 0;
+    transition: all 0.4s;
+  }
+
+  .switch input:checked ~ .slider .cloud {
+    opacity: 1;
+  }
+`;
+
+export default ThemeToggle;

--- a/frontend/components/layout/ThemeToggle.tsx
+++ b/frontend/components/layout/ThemeToggle.tsx
@@ -11,7 +11,7 @@ const ThemeToggle = () => {
   return (
     <StyledWrapper>
       <label className="switch" role="switch" aria-label="Toggle dark mode">
-        <input type="checkbox" checked={isDark} onChange={toggleTheme} />
+        <input type="checkbox" checked={!isDark} onChange={toggleTheme} />
         <span className="slider">
           <div className="star star_1" />
           <div className="star star_2" />

--- a/next.config.ts
+++ b/next.config.ts
@@ -30,7 +30,10 @@ const nextConfig = {
       }
     ],
   },
-  experimental: { 
+  compiler: {
+    styledComponents: true,
+  },
+  experimental: {
     serverActions: {
       bodySizeLimit: '10mb', 
     },

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@types/styled-components": "^5.1.34",
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -53,6 +54,7 @@
     "react-hook-form": "^7.54.2",
     "recharts": "^2.15.1",
     "resend": "^3.5.0",
+    "styled-components": "^6.1.19",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.2"


### PR DESCRIPTION
## Summary
- add styled-components to dependencies
- introduce ThemeProvider and ThemeToggle components
- enable styled-components compiler option
- wrap app with ThemeProvider and insert toggle next to the profile button

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68591860f4588326bcdaf4867e11ec65