### PR TITLE
Add human intervention feature

### DIFF
--- a/app/api/conversations/[id]/agent-message/route.ts
+++ b/app/api/conversations/[id]/agent-message/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/frontend/auth';
+import { appendMessages } from '@/app/conversations/actions';
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { text } = await request.json();
+  if (!text || !text.trim()) {
+    return NextResponse.json({ error: 'Missing text' }, { status: 400 });
+  }
+  await appendMessages(session.user.id, params.id, [
+    { role: 'agent', text, timestamp: new Date().toISOString() },
+  ]);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/conversations/[id]/route.ts
+++ b/app/api/conversations/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 import { auth } from '@/frontend/auth';
-import { deleteConversation } from '@/app/conversations/actions';
+import { deleteConversation, getConversation, setConversationHandledBy } from '@/app/conversations/actions';
 
 export async function DELETE(
   request: Request,
@@ -16,4 +16,35 @@ export async function DELETE(
   } catch (err: any) {
     return NextResponse.json({ error: err.message || 'Server error' }, { status: 500 });
   }
+}
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const conv = await getConversation(session.user.id, params.id);
+  if (!conv) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(conv);
+}
+
+export async function POST(
+  request: Request,
+  { params }: { params: { id: string } },
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { handledBy } = await request.json();
+  if (handledBy !== 'bot' && handledBy !== 'agent') {
+    return NextResponse.json({ error: 'Invalid handledBy' }, { status: 400 });
+  }
+  await setConversationHandledBy(session.user.id, params.id, handledBy);
+  return NextResponse.json({ success: true });
 }

--- a/backend/schemas/conversation.ts
+++ b/backend/schemas/conversation.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 
 export const ConversationMessageSchema = z.object({
-  role: z.enum(['user', 'assistant']),
+  role: z.enum(['user', 'assistant', 'agent']),
   text: z.string(),
   timestamp: z.date(),
 });
@@ -15,6 +15,7 @@ export const ConversationSchema = z.object({
   conversationId: z.string(),
   site: z.string().optional(),
   messages: z.array(ConversationMessageSchema),
+  handledBy: z.enum(['bot', 'agent']).default('bot'),
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),
 });

--- a/frontend/components/chatbot/ChatUI.tsx
+++ b/frontend/components/chatbot/ChatUI.tsx
@@ -7,13 +7,14 @@ import { Button } from '@/frontend/components/ui/button';
 import { Input } from '@/frontend/components/ui/input';
 import { ScrollArea } from '@/frontend/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/frontend/components/ui/avatar';
-import { Send, User, Bot, AlertTriangle } from 'lucide-react';
+import { Send, User, Bot, AlertTriangle, Headphones } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/frontend/lib/utils';
 
 function ChatMessage({ message }: { message: Message }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
+  const isAgent = message.role === 'agent';
   const isSystem = message.role === 'system';
 
   return (
@@ -25,15 +26,24 @@ function ChatMessage({ message }: { message: Message }) {
     >
       {!isUser && (
         <Avatar className="h-8 w-8 shrink-0">
-          <AvatarImage src="https://placehold.co/40x40/1a56db/FFFFFF.png?text=K" data-ai-hint="bot avatar" />
-          <AvatarFallback>{isAssistant ? <Bot size={18}/> : <AlertTriangle size={18}/>}</AvatarFallback>
+          <AvatarImage
+            src={isAssistant ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K' : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'}
+            data-ai-hint="bot avatar"
+          />
+          <AvatarFallback>
+            {isAssistant ? <Bot size={18}/> : isAgent ? <Headphones size={18}/> : <AlertTriangle size={18}/>} 
+          </AvatarFallback>
         </Avatar>
       )}
       <div
         className={cn(
           'max-w-xs md:max-w-md lg:max-w-lg rounded-xl px-4 py-3 shadow-md',
           isUser ? 'bg-primary text-primary-foreground rounded-br-none' : '',
-          isAssistant ? 'bg-card text-card-foreground rounded-bl-none border border-border' : '',
+          isAssistant
+            ? 'bg-card text-card-foreground rounded-bl-none border border-border'
+            : isAgent
+            ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
+            : '',
           isSystem ? 'bg-destructive/10 text-destructive-foreground border border-destructive/30 rounded-bl-none' : ''
         )}
       >

--- a/frontend/components/chatbot/ChatbotWidget.tsx
+++ b/frontend/components/chatbot/ChatbotWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { Send, Bot, User, X } from 'lucide-react';
+import { Send, Bot, User, X, Headphones } from 'lucide-react';
 import { Badge } from '@/frontend/components/ui/badge';
 import { format } from 'date-fns';
 import { it } from 'date-fns/locale';
@@ -19,7 +19,8 @@ interface ChatbotWidgetProps {
 
 export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
   const [open, setOpen] = useState(false);
-  const { messages, isLoading, sendMessage, addMessage } = useWidgetChat(userId);
+  const { messages, isLoading, sendMessage, addMessage, handledBy } = useWidgetChat(userId);
+  const prevHandledBy = useRef<'bot' | 'agent'>('bot');
   const [inputValue, setInputValue] = useState('');
   const viewportRef = useRef<HTMLDivElement>(null);
 
@@ -28,6 +29,13 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
       viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight });
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (handledBy === 'agent' && prevHandledBy.current !== 'agent') {
+      addMessage('system', 'Stai parlando con un operatore umano');
+    }
+    prevHandledBy.current = handledBy;
+  }, [handledBy, addMessage]);
 
   useEffect(() => {
     if (open && messages.length === 0) {
@@ -87,9 +95,15 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                   >
                     {msg.role !== 'user' && (
                       <Avatar className="h-8 w-8 shrink-0">
-                        <AvatarImage src="https://placehold.co/40x40/1a56db/FFFFFF.png?text=K" />
+                        <AvatarImage
+                          src={
+                            msg.role === 'assistant'
+                              ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K'
+                              : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'
+                          }
+                        />
                         <AvatarFallback>
-                          <Bot size={18} />
+                          {msg.role === 'assistant' ? <Bot size={18} /> : <Headphones size={18} />}
                         </AvatarFallback>
                       </Avatar>
                     )}
@@ -98,6 +112,8 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                         'max-w-[65%] rounded-lg px-3 py-2 shadow-md text-sm',
                         msg.role === 'user'
                           ? 'bg-[#1E3A8A] text-white rounded-br-none'
+                          : msg.role === 'agent'
+                          ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
                           : 'bg-card text-card-foreground rounded-bl-none border border-border',
                       )}
                     >

--- a/frontend/components/conversations/AgentControlBar.tsx
+++ b/frontend/components/conversations/AgentControlBar.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/frontend/components/ui/button';
+
+interface Props {
+  conversationId: string;
+  initialHandledBy: 'bot' | 'agent';
+  onChange?: (handledBy: 'bot' | 'agent') => void;
+}
+
+export default function AgentControlBar({ conversationId, initialHandledBy, onChange }: Props) {
+  const [handledBy, setHandledBy] = useState<'bot' | 'agent'>(initialHandledBy);
+
+  const toggle = async () => {
+    const next = handledBy === 'bot' ? 'agent' : 'bot';
+    await fetch(`/api/conversations/${conversationId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handledBy: next }),
+    });
+    setHandledBy(next);
+    onChange?.(next);
+  };
+
+  return (
+    <div className="p-2 border-t border-border bg-muted flex items-center justify-between">
+      <span className="text-sm">{handledBy === 'bot' ? 'Il bot sta rispondendo' : 'Operatore umano in controllo'}</span>
+      <Button size="sm" onClick={toggle} className="ml-2">
+        {handledBy === 'bot' ? 'Prendi il controllo' : 'Rilascia al bot'}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -3,11 +3,12 @@
 
 import { useState, useCallback } from 'react';
 import { generateChatResponse } from '@/app/chatbot/actions';
+import type { ChatMessage } from '@/backend/lib/buildPromptServer';
 import { useToast } from '@/frontend/hooks/use-toast';
 
 export interface Message {
   id: string;
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'agent';
   content: string;
   timestamp: Date;
 }
@@ -30,9 +31,9 @@ export function useChat() {
     addMessage('user', userMessageContent);
     setIsLoading(true);
 
-    const historyForAI = messages
-      .filter(msg => msg.role === 'user' || msg.role === 'assistant')
-      .map(msg => ({ role: msg.role, content: msg.content }));
+    const historyForAI: ChatMessage[] = messages
+      .filter((msg) => msg.role === 'user' || msg.role === 'assistant')
+      .map((msg) => ({ role: msg.role as 'user' | 'assistant', content: msg.content }));
       
     try {
       const result = await generateChatResponse(userMessageContent, historyForAI);


### PR DESCRIPTION
## Summary
- support `agent` role for conversations
- track who handles a conversation (`handledBy`)
- provide REST endpoints to control conversations and send agent messages
- poll for agent messages in the widget
- show agent/bot control bar in the dashboard with message form
- display agent messages with dedicated styling

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685921ffb5488326944d163709cfd905