### PR TITLE
Fix agent message handling

### DIFF
--- a/app/api/conversations/[id]/agent-message/route.ts
+++ b/app/api/conversations/[id]/agent-message/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/frontend/auth';
+import { appendMessages } from '@/app/conversations/actions';
+
+export async function POST(
+  request: Request,
+  { params }: any,
+) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { text } = await request.json();
+  if (!text || !text.trim()) {
+    return NextResponse.json({ error: 'Missing text' }, { status: 400 });
+  }
+  await appendMessages(session.user.id, params.id, [
+    { role: 'agent', text, timestamp: new Date().toISOString() },
+  ]);
+  return NextResponse.json({ success: true });
+}

--- a/app/api/conversations/[id]/updates/route.ts
+++ b/app/api/conversations/[id]/updates/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@/frontend/auth';
+import { getConversation } from '@/app/conversations/actions';
+
+export async function GET(req: Request, { params }: any) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { searchParams } = new URL(req.url);
+  const since = searchParams.get('since');
+  const conv = await getConversation(session.user.id, params.id);
+  if (!conv) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  let messages = conv.messages;
+  if (since) {
+    const sinceDate = new Date(since);
+    messages = messages.filter((m) => new Date(m.timestamp) > sinceDate);
+  }
+  return NextResponse.json({ messages, handledBy: conv.handledBy });
+}

--- a/backend/schemas/conversation.ts
+++ b/backend/schemas/conversation.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { ObjectId } from 'mongodb';
 
 export const ConversationMessageSchema = z.object({
-  role: z.enum(['user', 'assistant']),
+  role: z.enum(['user', 'assistant', 'agent']),
   text: z.string(),
   timestamp: z.date(),
 });
@@ -15,6 +15,7 @@ export const ConversationSchema = z.object({
   conversationId: z.string(),
   site: z.string().optional(),
   messages: z.array(ConversationMessageSchema),
+  handledBy: z.enum(['bot', 'agent']).default('bot'),
   createdAt: z.date().optional(),
   updatedAt: z.date().optional(),
 });

--- a/frontend/components/chatbot/ChatUI.tsx
+++ b/frontend/components/chatbot/ChatUI.tsx
@@ -7,13 +7,14 @@ import { Button } from '@/frontend/components/ui/button';
 import { Input } from '@/frontend/components/ui/input';
 import { ScrollArea } from '@/frontend/components/ui/scroll-area';
 import { Avatar, AvatarFallback, AvatarImage } from '@/frontend/components/ui/avatar';
-import { Send, User, Bot, AlertTriangle } from 'lucide-react';
+import { Send, User, Bot, AlertTriangle, Headphones } from 'lucide-react';
 import { format } from 'date-fns';
 import { cn } from '@/frontend/lib/utils';
 
 function ChatMessage({ message }: { message: Message }) {
   const isUser = message.role === 'user';
   const isAssistant = message.role === 'assistant';
+  const isAgent = message.role === 'agent';
   const isSystem = message.role === 'system';
 
   return (
@@ -25,15 +26,24 @@ function ChatMessage({ message }: { message: Message }) {
     >
       {!isUser && (
         <Avatar className="h-8 w-8 shrink-0">
-          <AvatarImage src="https://placehold.co/40x40/1a56db/FFFFFF.png?text=K" data-ai-hint="bot avatar" />
-          <AvatarFallback>{isAssistant ? <Bot size={18}/> : <AlertTriangle size={18}/>}</AvatarFallback>
+          <AvatarImage
+            src={isAssistant ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K' : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'}
+            data-ai-hint="bot avatar"
+          />
+          <AvatarFallback>
+            {isAssistant ? <Bot size={18}/> : isAgent ? <Headphones size={18}/> : <AlertTriangle size={18}/>} 
+          </AvatarFallback>
         </Avatar>
       )}
       <div
         className={cn(
           'max-w-xs md:max-w-md lg:max-w-lg rounded-xl px-4 py-3 shadow-md',
           isUser ? 'bg-primary text-primary-foreground rounded-br-none' : '',
-          isAssistant ? 'bg-card text-card-foreground rounded-bl-none border border-border' : '',
+          isAssistant
+            ? 'bg-card text-card-foreground rounded-bl-none border border-border'
+            : isAgent
+            ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
+            : '',
           isSystem ? 'bg-destructive/10 text-destructive-foreground border border-destructive/30 rounded-bl-none' : ''
         )}
       >

--- a/frontend/components/chatbot/ChatbotWidget.tsx
+++ b/frontend/components/chatbot/ChatbotWidget.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { Send, Bot, User, X } from 'lucide-react';
+import { Send, Bot, User, X, Headphones } from 'lucide-react';
 import { Badge } from '@/frontend/components/ui/badge';
 import { format } from 'date-fns';
 import { it } from 'date-fns/locale';
@@ -19,7 +19,8 @@ interface ChatbotWidgetProps {
 
 export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
   const [open, setOpen] = useState(false);
-  const { messages, isLoading, sendMessage, addMessage } = useWidgetChat(userId);
+  const { messages, isLoading, sendMessage, addMessage, handledBy } = useWidgetChat(userId);
+  const prevHandledBy = useRef<'bot' | 'agent'>('bot');
   const [inputValue, setInputValue] = useState('');
   const viewportRef = useRef<HTMLDivElement>(null);
 
@@ -28,6 +29,13 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
       viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight });
     }
   }, [messages]);
+
+  useEffect(() => {
+    if (handledBy === 'agent' && prevHandledBy.current !== 'agent') {
+      addMessage('system', 'Stai parlando con un operatore umano');
+    }
+    prevHandledBy.current = handledBy;
+  }, [handledBy, addMessage]);
 
   useEffect(() => {
     if (open && messages.length === 0) {
@@ -87,9 +95,15 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                   >
                     {msg.role !== 'user' && (
                       <Avatar className="h-8 w-8 shrink-0">
-                        <AvatarImage src="https://placehold.co/40x40/1a56db/FFFFFF.png?text=K" />
+                        <AvatarImage
+                          src={
+                            msg.role === 'assistant'
+                              ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K'
+                              : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'
+                          }
+                        />
                         <AvatarFallback>
-                          <Bot size={18} />
+                          {msg.role === 'assistant' ? <Bot size={18} /> : <Headphones size={18} />}
                         </AvatarFallback>
                       </Avatar>
                     )}
@@ -98,6 +112,8 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                         'max-w-[65%] rounded-lg px-3 py-2 shadow-md text-sm',
                         msg.role === 'user'
                           ? 'bg-[#1E3A8A] text-white rounded-br-none'
+                          : msg.role === 'agent'
+                          ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
                           : 'bg-card text-card-foreground rounded-bl-none border border-border',
                       )}
                     >

--- a/frontend/components/conversations/AgentControlBar.tsx
+++ b/frontend/components/conversations/AgentControlBar.tsx
@@ -1,0 +1,33 @@
+'use client';
+import { useState } from 'react';
+import { Button } from '@/frontend/components/ui/button';
+
+interface Props {
+  conversationId: string;
+  initialHandledBy: 'bot' | 'agent';
+  onChange?: (handledBy: 'bot' | 'agent') => void;
+}
+
+export default function AgentControlBar({ conversationId, initialHandledBy, onChange }: Props) {
+  const [handledBy, setHandledBy] = useState<'bot' | 'agent'>(initialHandledBy);
+
+  const toggle = async () => {
+    const next = handledBy === 'bot' ? 'agent' : 'bot';
+    await fetch(`/api/conversations/${conversationId}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handledBy: next }),
+    });
+    setHandledBy(next);
+    onChange?.(next);
+  };
+
+  return (
+    <div className="p-2 border-t border-border bg-muted flex items-center justify-between">
+      <span className="text-sm">{handledBy === 'bot' ? 'Il bot sta rispondendo' : 'Operatore umano in controllo'}</span>
+      <Button size="sm" onClick={toggle} className="ml-2">
+        {handledBy === 'bot' ? 'Prendi il controllo' : 'Rilascia al bot'}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/components/conversations/ConversationsClient.tsx
+++ b/frontend/components/conversations/ConversationsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ScrollArea } from '@/frontend/components/ui/scroll-area';
 import { Card, CardContent } from '@/frontend/components/ui/card';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/frontend/components/ui/dropdown-menu';
@@ -8,9 +8,10 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/frontend/components/u
 import { cn } from '@/frontend/lib/utils';
 import { format } from 'date-fns';
 import { MoreVertical, UserCircle } from 'lucide-react';
+import AgentControlBar from './AgentControlBar';
 
 export interface ConversationMessageDisplay {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'agent';
   text: string;
   timestamp: string;
 }
@@ -21,6 +22,7 @@ export interface ConversationDisplayItem {
   site?: string;
   createdAt?: string;
   updatedAt?: string;
+  handledBy?: 'bot' | 'agent';
 }
 
 interface Props {
@@ -31,6 +33,39 @@ export default function ConversationsClient({ conversations: initial }: Props) {
   const [conversations, setConversations] = useState(initial);
   const [selectedId, setSelectedId] = useState(initial[0]?.id || '');
   const selected = conversations.find((c) => c.id === selectedId);
+
+  useEffect(() => {
+    if (!selectedId) return;
+    let interval: NodeJS.Timeout;
+    const fetchConv = async () => {
+      try {
+        const res = await fetch(`/api/conversations/${selectedId}`);
+        if (res.ok) {
+          const data: ConversationDisplayItem = await res.json();
+          setConversations((prev) =>
+            prev.map((c) => (c.id === selectedId ? { ...c, ...data } : c)),
+          );
+        }
+      } catch {
+        // ignore
+      }
+    };
+    fetchConv();
+    interval = setInterval(fetchConv, 3000);
+    return () => clearInterval(interval);
+  }, [selectedId]);
+
+  useEffect(() => {
+    if (!selected) return;
+    const last = selected.messages[selected.messages.length - 1];
+    if (last && last.role === 'user' && typeof window !== 'undefined') {
+      if (Notification.permission === 'granted') {
+        new Notification('Nuovo messaggio', { body: last.text });
+      } else if (Notification.permission === 'default') {
+        Notification.requestPermission();
+      }
+    }
+  }, [selected]);
 
   const handleDelete = async (id: string) => {
     const res = await fetch(`/api/conversations/${id}`, { method: 'DELETE' });
@@ -102,24 +137,72 @@ export default function ConversationsClient({ conversations: initial }: Props) {
             </div>
 
             <CardContent className="flex-1 overflow-y-auto space-y-2 pt-4">
-              {selected.messages.map((msg, idx) => (
-                <div key={idx} className={cn('flex', msg.role === 'user' ? 'justify-end' : 'justify-start')}>
-                  <div
-                    className={cn(
-                      'rounded-xl px-3 py-2 max-w-[75%]',
-                      msg.role === 'user'
-                        ? 'bg-primary text-primary-foreground rounded-br-none'
-                        : 'bg-muted text-foreground rounded-bl-none border border-border'
-                    )}
-                  >
-                    <p className="text-sm whitespace-pre-wrap">{msg.text}</p>
-                    <p className={cn('text-xs mt-1', msg.role === 'user' ? 'text-primary-foreground/70 text-right' : 'text-muted-foreground text-left')}>
-                      {format(new Date(msg.timestamp), 'Pp')}
-                    </p>
+              {selected.messages.map((msg, idx) => {
+                const isUser = msg.role === 'user';
+                const isAgent = msg.role === 'agent';
+                return (
+                  <div key={idx} className={cn('flex', isUser ? 'justify-end' : 'justify-start')}>
+                    <div
+                      className={cn(
+                        'rounded-xl px-3 py-2 max-w-[75%]',
+                        isUser
+                          ? 'bg-primary text-primary-foreground rounded-br-none'
+                          : isAgent
+                          ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
+                          : 'bg-muted text-foreground rounded-bl-none border border-border'
+                      )}
+                    >
+                      <p className="text-sm whitespace-pre-wrap">{msg.text}</p>
+                      <p className={cn('text-xs mt-1', isUser ? 'text-primary-foreground/70 text-right' : 'text-muted-foreground text-left')}>
+                        {format(new Date(msg.timestamp), 'Pp')}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </CardContent>
+            <AgentControlBar
+              conversationId={selected.id}
+              initialHandledBy={selected.handledBy || 'bot'}
+              onChange={(val) => {
+                setConversations((prev) => prev.map((c) => (c.id === selected.id ? { ...c, handledBy: val } : c)));
+              }}
+            />
+            {selected.handledBy === 'agent' && (
+              <form
+                onSubmit={async (e) => {
+                  e.preventDefault();
+                  const form = e.target as HTMLFormElement;
+                  const input = form.elements.namedItem('agentMsg') as HTMLInputElement;
+                  const text = input.value.trim();
+                  if (!text) return;
+                  const res = await fetch(`/api/conversations/${selected.id}/agent-message`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ text }),
+                  });
+                  if (res.ok) {
+                    const msg: ConversationMessageDisplay = {
+                      role: 'agent',
+                      text,
+                      timestamp: new Date().toISOString(),
+                    };
+                    setConversations((prev) =>
+                      prev.map((c) =>
+                        c.id === selected.id
+                          ? { ...c, messages: [...c.messages, msg] }
+                          : c,
+                      ),
+                    );
+                  }
+                  input.value = '';
+                }}
+                className="p-2 border-t flex gap-2"
+              >
+                <input name="agentMsg" className="flex-1 border rounded px-2 py-1" placeholder="Scrivi una risposta" />
+                <button type="submit" className="px-3 py-1 rounded bg-primary text-primary-foreground">Invia</button>
+              </form>
+            )}
           </Card>
         ) : (
           <div className="p-4 text-muted-foreground">Nessuna conversazione selezionata.</div>

--- a/frontend/hooks/useChat.ts
+++ b/frontend/hooks/useChat.ts
@@ -3,11 +3,12 @@
 
 import { useState, useCallback } from 'react';
 import { generateChatResponse } from '@/app/chatbot/actions';
+import type { ChatMessage } from '@/backend/lib/buildPromptServer';
 import { useToast } from '@/frontend/hooks/use-toast';
 
 export interface Message {
   id: string;
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'agent';
   content: string;
   timestamp: Date;
 }
@@ -30,9 +31,9 @@ export function useChat() {
     addMessage('user', userMessageContent);
     setIsLoading(true);
 
-    const historyForAI = messages
-      .filter(msg => msg.role === 'user' || msg.role === 'assistant')
-      .map(msg => ({ role: msg.role, content: msg.content }));
+    const historyForAI: ChatMessage[] = messages
+      .filter((msg) => msg.role === 'user' || msg.role === 'assistant')
+      .map((msg) => ({ role: msg.role as 'user' | 'assistant', content: msg.content }));
       
     try {
       const result = await generateChatResponse(userMessageContent, historyForAI);

--- a/frontend/hooks/useWidgetChat.ts
+++ b/frontend/hooks/useWidgetChat.ts
@@ -4,7 +4,7 @@ import { useState, useCallback, useRef, useEffect } from 'react';
 
 export interface Message {
   id: string;
-  role: 'user' | 'assistant' | 'system';
+  role: 'user' | 'assistant' | 'system' | 'agent';
   content: string;
   timestamp: Date;
 }
@@ -12,7 +12,9 @@ export interface Message {
 export function useWidgetChat(userId: string) {
   const [messages, setMessages] = useState<Message[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [handledBy, setHandledBy] = useState<'bot' | 'agent'>('bot');
   const conversationIdRef = useRef<string>('');
+  const lastTimestampRef = useRef<string>('');
   const storageKey = `kommander_conversation_${userId}`;
   const site = typeof window !== 'undefined' ? window.location.hostname : '';
 
@@ -25,6 +27,68 @@ export function useWidgetChat(userId: string) {
     }
   }, [storageKey]);
 
+  useEffect(() => {
+    let interval: NodeJS.Timeout | null = null;
+
+    const fetchConversation = async () => {
+      if (!conversationIdRef.current) return;
+      try {
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_BASE_URL}/api/conversations/${conversationIdRef.current}`,
+        );
+        if (res.ok) {
+          const data = await res.json();
+          setHandledBy(data.handledBy || 'bot');
+          const msgs = data.messages.map((m: any) => ({
+            id: m.timestamp + m.role,
+            role: m.role,
+            content: m.text,
+            timestamp: new Date(m.timestamp),
+          }));
+          setMessages(msgs);
+          if (msgs.length) {
+            lastTimestampRef.current = msgs[msgs.length - 1].timestamp.toISOString();
+          }
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    const fetchUpdates = async () => {
+      if (!conversationIdRef.current || !lastTimestampRef.current) return;
+      try {
+        const url = `${process.env.NEXT_PUBLIC_BASE_URL}/api/conversations/${conversationIdRef.current}/updates?since=${encodeURIComponent(lastTimestampRef.current)}`;
+        const res = await fetch(url);
+        if (res.ok) {
+          const data = await res.json();
+          setHandledBy(data.handledBy || 'bot');
+          const newMsgs = (data.messages || []).map((m: any) => ({
+            id: m.timestamp + m.role,
+            role: m.role,
+            content: m.text,
+            timestamp: new Date(m.timestamp),
+          }));
+          if (newMsgs.length) {
+            lastTimestampRef.current = newMsgs[newMsgs.length - 1].timestamp.toISOString();
+            setMessages((prev) => [...prev, ...newMsgs]);
+          }
+        }
+      } catch {
+        // ignore
+      }
+    };
+
+    if (handledBy === 'agent') {
+      fetchConversation();
+      interval = setInterval(fetchUpdates, 1000);
+    }
+
+    return () => {
+      if (interval) clearInterval(interval);
+    };
+  }, [handledBy, userId]);
+
   const addMessage = (role: Message['role'], content: string) => {
     setMessages((prev) => [
       ...prev,
@@ -35,6 +99,7 @@ export function useWidgetChat(userId: string) {
         timestamp: new Date(),
       },
     ]);
+    lastTimestampRef.current = new Date().toISOString();
   };
 
   const sendMessage = useCallback(
@@ -65,15 +130,19 @@ export function useWidgetChat(userId: string) {
 
         const data = await res.json();
 
+        if (data.conversationId) {
+          conversationIdRef.current = data.conversationId;
+          if (typeof window !== 'undefined') {
+            localStorage.setItem(storageKey, conversationIdRef.current);
+          }
+        }
+
+        if (data.handledBy) {
+          setHandledBy(data.handledBy);
+        }
+
         if (data.reply) {
           addMessage('assistant', data.reply);
-
-          if (data.conversationId) {
-            conversationIdRef.current = data.conversationId;
-            if (typeof window !== 'undefined') {
-              localStorage.setItem(storageKey, conversationIdRef.current);
-            }
-          }
         } else if (data.error) {
           addMessage('system', `Error: ${data.error}`);
         }
@@ -86,5 +155,5 @@ export function useWidgetChat(userId: string) {
     [userId, site, storageKey]
   );
 
-  return { messages, isLoading, sendMessage, addMessage };
+  return { messages, isLoading, sendMessage, addMessage, handledBy, setHandledBy };
 }


### PR DESCRIPTION
## Summary
- improve ConversationsClient with polling to fetch updates
- update local state after sending agent messages
- adjust API routes to avoid TS errors in generated types
- poll conversation updates from widget for near-instant agent messages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685921ffb5488326944d163709cfd905