### PR TITLE
Prevent duplicate AI reply when requesting human operator

### DIFF
--- a/public/chatbot.js
+++ b/public/chatbot.js
@@ -145,6 +145,13 @@
       if (!text) return;
 
       addMessage('user', text);
+      const isHumanRequest = text.toLowerCase().includes('operatore umano');
+      if (isHumanRequest) {
+        addMessage(
+          'assistant',
+          'Certamente! Ti metto subito in contatto con uno specialista. Nel frattempo, se vuoi, puoi continuare a farmi domande: potrei gi\u00e0 aiutarti a trovare una soluzione mentre attendi la risposta di un operatore.'
+        );
+      }
       setInput('');
 
       try {
@@ -178,7 +185,7 @@
           setHandledBy(data.handledBy);
         }
 
-        if (data.reply) {
+        if (data.reply && !isHumanRequest) {
           addMessage('assistant', data.reply);
         } else if (data.error) {
           addMessage('system', 'Error: ' + data.error);


### PR DESCRIPTION
## Summary
- ignore server reply when user explicitly asks for a human operator

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68593f1b75d48326b1da471e743e2ab0