### PR TITLE
Add customizable chatbot settings

### DIFF
--- a/app/api/settings/[userId]/route.ts
+++ b/app/api/settings/[userId]/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { connectToDatabase } from '@/backend/lib/mongodb';
+import type { ChatbotSettingsDocument } from '@/backend/schemas/settings';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, { params }: { params: { userId: string } }) {
+  const userId = params.userId;
+  if (!userId) return NextResponse.json({ error: 'Missing userId' }, { status: 400 });
+  const { db } = await connectToDatabase();
+  const doc = await db.collection<ChatbotSettingsDocument>('chatbot_settings').findOne({ userId });
+  return NextResponse.json(doc || {});
+}

--- a/app/chatbot-trial/page.tsx
+++ b/app/chatbot-trial/page.tsx
@@ -4,12 +4,14 @@ import { Badge } from "@/frontend/components/ui/badge";
 import { format } from 'date-fns';
 import { it } from 'date-fns/locale';
 import { auth } from "@/frontend/auth";
+import { getSettings } from '@/app/settings/actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ChatbotTrialPage() {
   const session = await auth();
   const userId = session?.user?.id || '';
+  const settings = await getSettings();
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://kommanderai.vercel.app';
   const snippet = `<div id="kommander-chatbot"></div>
 <script src="${baseUrl}/chatbot.js"></script>
@@ -24,17 +26,18 @@ export default async function ChatbotTrialPage() {
         <InfoPanel snippet={snippet} shareUrl={shareUrl} />
       </div>
       <div className="md:w-3/5 h-[80vh]">
-        <ChatUI
-          containerClassName="h-full"
-          headerClassName="bg-[#1E3A8A] text-white px-4 py-3 rounded-t-lg"
-          headerExtras={(
-            <div className="flex items-center gap-2">
-              <Badge className="bg-green-600 text-white border-none">Online</Badge>
-              <span className="text-sm">{currentDate}</span>
-            </div>
-          )}
-          title="Kommander.ai – Trial"
-        />
+          <ChatUI
+            containerClassName="h-full"
+            headerClassName="text-white px-4 py-3 rounded-t-lg"
+            accentColor={settings?.color}
+            title={`${settings?.name || 'Kommander.ai'} – Trial`}
+            headerExtras={(
+              <div className="flex items-center gap-2">
+                <Badge className="bg-green-600 text-white border-none">Online</Badge>
+                <span className="text-sm">{currentDate}</span>
+              </div>
+            )}
+          />
       </div>
     </div>
   );

--- a/app/chatbot/actions.ts
+++ b/app/chatbot/actions.ts
@@ -7,6 +7,7 @@ import { buildPromptServer, type ChatMessage, type DocumentSnippet } from '@/bac
 import type { Faq } from '@/backend/schemas/faq';
 import { getFileContent } from '@/app/training/actions';
 import { auth } from '@/frontend/auth'; // Import auth for session
+import { getSettings } from '@/app/settings/actions';
 
 import mammoth from 'mammoth';
 
@@ -112,7 +113,7 @@ export async function generateChatResponse(
         fileName: fileNameMap.get(doc.gridFsFileId.toString()) || 'Documento',
         summary: doc.summary as string,
     }));
-    
+
     const extractedTextSnippets: DocumentSnippet[] = [];
 
     for (const fileMeta of filesToProcess) {
@@ -129,6 +130,8 @@ export async function generateChatResponse(
         extractedTextSnippets.push({ fileName: fileMeta.fileName, snippet: text });
       }
     }
+
+    const userSettings = await getSettings();
     const messages = buildPromptServer(
       userMessage,
       faqs,
@@ -136,6 +139,7 @@ export async function generateChatResponse(
       extractedTextSnippets,
       history,
       summariesForPrompt,
+      userSettings || undefined,
     );
 
     const openai = getOpenAI();

--- a/app/chatbot/page.tsx
+++ b/app/chatbot/page.tsx
@@ -1,11 +1,13 @@
 import ChatUI from '@/frontend/components/chatbot/ChatUI';
 import { auth } from '@/frontend/auth';
+import { getSettings } from '@/app/settings/actions';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ChatbotPage() {
   const session = await auth();
   const userId = session?.user?.id || '';
+  const settings = await getSettings();
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://kommanderai.vercel.app';
 
   const snippet = `<div id="kommander-chatbot"></div>
@@ -39,7 +41,7 @@ export default async function ChatbotPage() {
 
       {/* Contenitore della chat */}
       <div className="flex-1 overflow-hidden">
-        <ChatUI />
+        <ChatUI accentColor={settings?.color} title={`${settings?.name || 'Kommander.ai'} Chat`} />
       </div>
     </div>
   );

--- a/app/settings/SettingsClient.tsx
+++ b/app/settings/SettingsClient.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import { Input } from '@/frontend/components/ui/input';
+import { Button } from '@/frontend/components/ui/button';
+import { RadioGroup, RadioGroupItem } from '@/frontend/components/ui/radio-group';
+import { Checkbox } from '@/frontend/components/ui/checkbox';
+import { saveSettings } from './actions';
+
+const traitOptions = [
+  { value: 'avventuroso', label: '🦁 Avventuroso' },
+  { value: 'fiducioso', label: '💪 Fiducioso' },
+  { value: 'convincente', label: '🤝 Convincente' },
+  { value: 'energetico', label: '⚡ Energetico' },
+  { value: 'amichevole', label: '🙂 Amichevole' },
+  { value: 'divertente', label: '🤣 Divertente' },
+  { value: 'ironico', label: '😜 Ironico' },
+  { value: 'professionista', label: '💼 Professionista' },
+] as const;
+type Trait = typeof traitOptions[number]['value'];
+
+interface Props {
+  initialSettings: any | null;
+}
+
+export default function SettingsClient({ initialSettings }: Props) {
+  const [name, setName] = useState(initialSettings?.name || 'Kommander.ai');
+  const [color, setColor] = useState(initialSettings?.color || '#1E3A8A');
+  const [personality, setPersonality] = useState(initialSettings?.personality || 'neutral');
+  const [traits, setTraits] = useState<Trait[]>(initialSettings?.traits || []);
+  const [saving, setSaving] = useState(false);
+
+  const toggleTrait = (t: Trait) => {
+    setTraits(prev => {
+      if (prev.includes(t)) {
+        return prev.filter(x => x !== t);
+      }
+      if (prev.length >= 3) return prev;
+      return [...prev, t];
+    });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    await saveSettings({ name, color, personality, traits });
+    setSaving(false);
+  };
+
+  return (
+    <div className="container mx-auto space-y-6 pb-8">
+      <div>
+        <h1 className="text-3xl font-headline font-bold mb-2 text-foreground">Settings</h1>
+        <p className="text-muted-foreground">Customize your chatbot.</p>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-6">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Chatbot Name</label>
+          <Input value={name} onChange={(e) => setName(e.target.value)} className="bg-background" />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Color</label>
+          <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} className="w-20 h-10 p-1" />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Personality</label>
+          <RadioGroup value={personality} onValueChange={setPersonality} className="flex gap-4">
+            <label className="flex items-center gap-2 text-sm">
+              <RadioGroupItem value="neutral" id="p-neutral" />
+              <span>👋 Neutro</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <RadioGroupItem value="casual" id="p-casual" />
+              <span>🤙 Casual</span>
+            </label>
+            <label className="flex items-center gap-2 text-sm">
+              <RadioGroupItem value="formal" id="p-formal" />
+              <span>🤝 Formale</span>
+            </label>
+          </RadioGroup>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium">Carattere (max 3)</label>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 md:grid-cols-4">
+            {traitOptions.map((t) => (
+              <label key={t.value} className="flex items-center gap-2 text-sm">
+                <Checkbox checked={traits.includes(t.value)} onCheckedChange={() => toggleTrait(t.value)} />
+                <span>{t.label}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+        <div className="flex justify-end">
+          <Button type="submit" disabled={saving}>{saving ? 'Saving...' : 'Save'}</Button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/app/settings/actions.ts
+++ b/app/settings/actions.ts
@@ -1,0 +1,40 @@
+'use server';
+
+import { connectToDatabase } from '@/backend/lib/mongodb';
+import { ChatbotSettingsSchema, type ChatbotSettingsDocument } from '@/backend/schemas/settings';
+import { revalidatePath } from 'next/cache';
+import { auth } from '@/frontend/auth';
+import { ObjectId } from 'mongodb';
+
+export async function getSettings(): Promise<ChatbotSettingsDocument | null> {
+  const session = await auth();
+  if (!session?.user?.id) return null;
+  const { db } = await connectToDatabase();
+  const doc = await db
+    .collection<ChatbotSettingsDocument>('chatbot_settings')
+    .findOne({ userId: session.user.id });
+  return doc || null;
+}
+
+export async function saveSettings(data: Partial<ChatbotSettingsDocument>) {
+  const session = await auth();
+  if (!session?.user?.id) return { error: 'Not authenticated' };
+  const userId = session.user.id;
+  const { db } = await connectToDatabase();
+
+  const parsed = ChatbotSettingsSchema.omit({ _id: true, userId: true, createdAt: true, updatedAt: true }).partial().safeParse(data);
+  if (!parsed.success) {
+    return { error: 'Invalid data' };
+  }
+
+  const update = {
+    $set: { ...parsed.data, updatedAt: new Date() },
+    $setOnInsert: { userId, createdAt: new Date() },
+  };
+  await db
+    .collection<ChatbotSettingsDocument>('chatbot_settings')
+    .updateOne({ userId }, update, { upsert: true });
+
+  revalidatePath('/settings');
+  return { success: true };
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,9 @@
+import SettingsClient from './SettingsClient';
+import { getSettings } from './actions';
+
+export const dynamic = 'force-dynamic';
+
+export default async function SettingsPage() {
+  const settings = await getSettings();
+  return <SettingsClient initialSettings={settings} />;
+}

--- a/backend/lib/buildPromptServer.ts
+++ b/backend/lib/buildPromptServer.ts
@@ -27,10 +27,19 @@ export function buildPromptServer(
   uploadedFilesInfo: UploadedFileInfoForPromptContext[],
   extractedTextSnippets: DocumentSnippet[] = [],
   history: ChatMessage[] = [],
-  fileSummaries: FileSummaryForPrompt[] = []
+  fileSummaries: FileSummaryForPrompt[] = [],
+  settings?: { name?: string; personality?: string; traits?: string[] }
 ): ChatMessage[] {
   
-  let context = "Sei Kommander.ai, un assistente AI utile. Usa le seguenti informazioni per rispondere alla query dell'utente.\n\n";
+  const botName = settings?.name || 'Kommander.ai';
+  let context = `Sei ${botName}, un assistente AI utile.`;
+  if (settings?.personality) {
+    context += ` Stile comunicativo: ${settings.personality}.`;
+  }
+  if (settings?.traits && settings.traits.length) {
+    context += ` Carattere: ${settings.traits.join(', ')}.`;
+  }
+  context += " Usa le seguenti informazioni per rispondere alla query dell'utente.\n\n";
 
   if (faqs.length > 0) {
     context += "FAQ Rilevanti:\n";

--- a/backend/schemas/settings.ts
+++ b/backend/schemas/settings.ts
@@ -1,0 +1,24 @@
+import { z } from 'zod';
+import { ObjectId } from 'mongodb';
+
+export const ChatbotSettingsSchema = z.object({
+  _id: z.custom<ObjectId>(val => typeof val === 'object' || ObjectId.isValid(val as string)).optional(),
+  userId: z.string(),
+  name: z.string().default('Kommander.ai'),
+  color: z.string().default('#1E3A8A'),
+  personality: z.enum(['neutral', 'casual', 'formal']).default('neutral'),
+  traits: z.array(z.enum([
+    'avventuroso',
+    'fiducioso',
+    'convincente',
+    'energetico',
+    'amichevole',
+    'divertente',
+    'ironico',
+    'professionista',
+  ])).max(3).default([]),
+  createdAt: z.date().optional(),
+  updatedAt: z.date().optional(),
+});
+
+export type ChatbotSettingsDocument = z.infer<typeof ChatbotSettingsSchema>;

--- a/frontend/components/chatbot/ChatUI.tsx
+++ b/frontend/components/chatbot/ChatUI.tsx
@@ -70,6 +70,7 @@ interface ChatUIProps {
   headerClassName?: string;
   headerExtras?: React.ReactNode;
   title?: string;
+  accentColor?: string;
 }
 
 export default function ChatUI({
@@ -77,6 +78,7 @@ export default function ChatUI({
   headerClassName,
   headerExtras,
   title = 'Kommander.ai Chat',
+  accentColor,
 }: ChatUIProps) {
   const { messages, isLoading, sendMessage } = useChat();
   const [inputValue, setInputValue] = useState('');
@@ -107,6 +109,7 @@ export default function ChatUI({
           'p-4 border-b border-border flex items-center justify-between',
           headerClassName
         )}
+        style={accentColor ? { backgroundColor: accentColor, color: '#fff' } : undefined}
       >
         <h2 className="text-xl font-semibold font-headline">
           {title}
@@ -122,7 +125,7 @@ export default function ChatUI({
           {isLoading && (
             <div className="flex items-center space-x-2 p-2 text-muted-foreground">
               <Bot className="w-5 h-5 animate-pulse" />
-              <span>Kommander.ai is typing...</span>
+              <span>{title} is typing...</span>
             </div>
           )}
         </div>

--- a/frontend/components/chatbot/ChatbotWidget.tsx
+++ b/frontend/components/chatbot/ChatbotWidget.tsx
@@ -23,6 +23,18 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
   const prevHandledBy = useRef<'bot' | 'agent'>('bot');
   const [inputValue, setInputValue] = useState('');
   const viewportRef = useRef<HTMLDivElement>(null);
+  const [botName, setBotName] = useState('Kommander.ai');
+  const [botColor, setBotColor] = useState('#1E3A8A');
+
+  useEffect(() => {
+    fetch(`/api/settings/${userId}`)
+      .then(res => res.json())
+      .then(data => {
+        if (data.name) setBotName(data.name);
+        if (data.color) setBotColor(data.color);
+      })
+      .catch(() => {});
+  }, [userId]);
 
   useEffect(() => {
     if (viewportRef.current) {
@@ -39,7 +51,7 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
 
   useEffect(() => {
     if (open && messages.length === 0) {
-      addMessage('assistant', 'Ciao, sono Kommander.ai! Come posso aiutarti oggi?');
+      addMessage('assistant', `Ciao, sono ${botName}! Come posso aiutarti oggi?`);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
@@ -57,7 +69,8 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
     <>
       <motion.button
         onClick={() => setOpen(!open)}
-        className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-[#1E3A8A] text-white shadow-lg"
+        className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full text-white shadow-lg"
+        style={{ backgroundColor: botColor }}
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.95 }}
         aria-label="Apri chat"
@@ -73,8 +86,8 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
             transition={{ duration: 0.2 }}
             className="fixed inset-0 sm:bottom-20 sm:right-4 sm:inset-auto z-50 flex w-full h-full sm:w-[400px] sm:h-[600px] flex-col bg-card border border-border rounded-none sm:rounded-lg shadow-xl"
           >
-            <div className="px-4 py-3 flex items-center justify-between bg-[#1E3A8A] text-white rounded-t-lg">
-              <span className="font-semibold">Kommander.ai – Trial</span>
+            <div className="px-4 py-3 flex items-center justify-between rounded-t-lg text-white" style={{ backgroundColor: botColor }}>
+              <span className="font-semibold">{botName} – Trial</span>
               <div className="flex items-center gap-2">
                 <Badge className="bg-green-600 text-white border-none">Online</Badge>
                 <span className="text-sm">{currentDate}</span>
@@ -111,11 +124,12 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                       className={cn(
                         'max-w-[65%] rounded-lg px-3 py-2 shadow-md text-sm',
                         msg.role === 'user'
-                          ? 'bg-[#1E3A8A] text-white rounded-br-none'
+                          ? 'text-white rounded-br-none'
                           : msg.role === 'agent'
                           ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
                           : 'bg-card text-card-foreground rounded-bl-none border border-border',
                       )}
+                      style={msg.role === 'user' ? { backgroundColor: botColor } : undefined}
                     >
                       <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
                       <p
@@ -142,7 +156,7 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
                 {isLoading && (
                   <div className="text-muted-foreground text-sm flex items-center space-x-2">
                     <Bot className="w-4 h-4 animate-pulse" />
-                    <span>Typing...</span>
+                    <span>{botName} sta scrivendo...</span>
                   </div>
                 )}
               </div>

--- a/frontend/components/layout/Sidebar.tsx
+++ b/frontend/components/layout/Sidebar.tsx
@@ -3,7 +3,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { BookOpen, MessageCircle, MessageSquare, type LucideIcon } from 'lucide-react';
+import { BookOpen, MessageCircle, MessageSquare, Settings as SettingsIcon, type LucideIcon } from 'lucide-react';
 import { cn } from '@/frontend/lib/utils';
 import React from 'react';
 
@@ -18,6 +18,7 @@ const navItems: NavItem[] = [
   { href: '/training', label: 'Training', icon: BookOpen, id: 'sidebar-training' },
   { href: '/chatbot-trial', label: 'Chatbot Trial', icon: MessageCircle, id: 'sidebar-chatbot' },
   { href: '/conversations', label: 'Conversazioni', icon: MessageSquare, id: 'sidebar-conversations' },
+  { href: '/settings', label: 'Settings', icon: SettingsIcon, id: 'sidebar-settings' },
 ];
 
 export default function Sidebar() {


### PR DESCRIPTION
## Summary
- add schema and server actions for user chatbot settings
- create Settings page with form to configure name, color, personality and traits
- expose `/api/settings/[userId]` for widget
- update Chatbot widget/UI components to use settings
- adjust prompt builder with personality/traits
- include new page in sidebar

## Testing
- `npm run lint`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_685ac44fe9e8832681a1485ea7a54525