### PR TITLE
Add fixed navbar

### DIFF
--- a/frontend/components/layout/AppLayout.tsx
+++ b/frontend/components/layout/AppLayout.tsx
@@ -3,37 +3,26 @@
 
 import React from 'react';
 import Sidebar from '@/frontend/components/layout/Sidebar';
-import KommanderIcon from '@/frontend/components/layout/KommanderIcon';
-import UserProfileButton from '@/frontend/components/layout/UserProfileButton';
-import ThemeToggle from '@/frontend/components/layout/ThemeToggle';
-import Link from 'next/link';
+import Navbar from '@/frontend/components/layout/Navbar';
 import { usePathname } from 'next/navigation';
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const showAuthElements = pathname !== '/login'; 
+  const showAuthElements = !['/login', '/signup'].includes(pathname);
 
   return (
     <div className="relative flex flex-col min-h-screen bg-background">
+      {showAuthElements && <Navbar />}
+
       {showAuthElements && (
-        <div className="fixed left-4 top-8 z-30 flex flex-col items-start space-y-3">
-          <div className="flex-shrink-0 w-16 flex justify-center">
-            <Link href="/training" className="inline-flex items-center justify-center" aria-label="Go to Training page">
-              <KommanderIcon />
-            </Link>
-          </div>
+        <div className="fixed left-4 top-20 z-30 flex flex-col items-start space-y-3">
           <Sidebar />
         </div>
       )}
 
-      {showAuthElements && (
-        <div className="fixed right-6 top-4 z-40 flex items-center gap-4">
-          <ThemeToggle />
-          <UserProfileButton />
-        </div>
-      )}
-      
-      <main className={`flex-1 overflow-y-auto p-6 ${showAuthElements ? 'pl-[6rem] md:pl-[6.25rem] lg:pl-[6.5rem] pr-[4rem]' : ''}`}>
+      <main
+        className={`flex-1 overflow-y-auto p-6 ${showAuthElements ? 'pt-[calc(5rem+1px)] pl-[6rem] md:pl-[6.25rem] lg:pl-[6.5rem] pr-[4rem]' : ''}`}
+      >
         {children}
       </main>
     </div>

--- a/frontend/components/layout/Navbar.tsx
+++ b/frontend/components/layout/Navbar.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import KommanderIcon from '@/frontend/components/layout/KommanderIcon';
+import UserProfileButton from '@/frontend/components/layout/UserProfileButton';
+import ThemeToggle from '@/frontend/components/layout/ThemeToggle';
+
+export default function Navbar() {
+  const pathname = usePathname();
+  const showProfile = pathname !== '/login';
+
+  return (
+    <header className="fixed top-0 left-0 right-0 z-40 flex items-center justify-between bg-background py-2 pr-4">
+      <Link href="/training" aria-label="Go to Training page" className="ml-4 flex w-16 justify-center">
+        <KommanderIcon />
+      </Link>
+      <div className="flex items-center gap-4">
+        <ThemeToggle />
+        {showProfile && <UserProfileButton />}
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Summary
- create `Navbar` component rendering logo and user profile
- integrate new navbar in `AppLayout`
- include `ThemeToggle` in the navbar
- center the Kommander logo above the sidebar
- tweak spacing between the navbar and content
- hide navbar on `/login` page
- remove navbar padding on auth pages

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685d7eb2405883269ba7d825878b5bb0