### PR TITLE
Refactor chat UI with reusable wrapper

### DIFF
--- a/frontend/components/chatbot/ChatUI.tsx
+++ b/frontend/components/chatbot/ChatUI.tsx
@@ -1,69 +1,10 @@
 
 "use client";
 
-import React, { useState, useRef, useEffect } from 'react';
-import { useChat, type Message } from '@/frontend/hooks/useChat';
-import { Button } from '@/frontend/components/ui/button';
-import { Input } from '@/frontend/components/ui/input';
-import { ScrollArea } from '@/frontend/components/ui/scroll-area';
-import { Avatar, AvatarFallback, AvatarImage } from '@/frontend/components/ui/avatar';
-import { Send, User, Bot, AlertTriangle, Headphones } from 'lucide-react';
-import { format } from 'date-fns';
+import React, { useState } from 'react';
+import { useChat } from '@/frontend/hooks/useChat';
+import ChatUIWrapper from '@/frontend/components/chatbot/ChatUIWrapper';
 import { cn } from '@/frontend/lib/utils';
-
-function ChatMessage({ message }: { message: Message }) {
-  const isUser = message.role === 'user';
-  const isAssistant = message.role === 'assistant';
-  const isAgent = message.role === 'agent';
-  const isSystem = message.role === 'system';
-
-  return (
-    <div
-      className={cn(
-        'flex items-end space-x-3 py-3 px-1',
-        isUser ? 'justify-end' : 'justify-start'
-      )}
-    >
-      {!isUser && (
-        <Avatar className="h-8 w-8 shrink-0">
-          <AvatarImage
-            src={isAssistant ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K' : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'}
-            data-ai-hint="bot avatar"
-          />
-          <AvatarFallback>
-            {isAssistant ? <Bot size={18}/> : isAgent ? <Headphones size={18}/> : <AlertTriangle size={18}/>} 
-          </AvatarFallback>
-        </Avatar>
-      )}
-      <div
-        className={cn(
-          'max-w-xs md:max-w-md lg:max-w-lg rounded-xl px-4 py-3 shadow-md',
-          isUser ? 'bg-primary text-primary-foreground rounded-br-none' : '',
-          isAssistant
-            ? 'bg-card text-card-foreground rounded-bl-none border border-border'
-            : isAgent
-            ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
-            : '',
-          isSystem ? 'bg-destructive/10 text-destructive-foreground border border-destructive/30 rounded-bl-none' : ''
-        )}
-      >
-        <p className="text-sm whitespace-pre-wrap">{message.content}</p>
-        <p className={cn(
-             "text-xs mt-1.5",
-             isUser ? "text-primary-foreground/70 text-right" : "text-muted-foreground text-left"
-           )}>
-          {format(message.timestamp, 'p')}
-        </p>
-      </div>
-      {isUser && (
-        <Avatar className="h-8 w-8 shrink-0">
-          <AvatarImage src="https://placehold.co/40x40/8cb0eA/1A202C.png?text=U" data-ai-hint="user avatar" />
-          <AvatarFallback><User size={18}/></AvatarFallback>
-        </Avatar>
-      )}
-    </div>
-  );
-}
 
 interface ChatUIProps {
   containerClassName?: string;
@@ -82,71 +23,19 @@ export default function ChatUI({
 }: ChatUIProps) {
   const { messages, isLoading, sendMessage } = useChat();
   const [inputValue, setInputValue] = useState('');
-  const scrollAreaRef = useRef<HTMLDivElement>(null);
-  const viewportRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (viewportRef.current) {
-      viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight, behavior: 'smooth' });
-    }
-  }, [messages]);
-
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (inputValue.trim()) {
-      sendMessage(inputValue);
-      setInputValue('');
-    }
-  };
 
   return (
-    <div className={cn(
-        "flex flex-col h-full w-full bg-card shadow-xl rounded-lg border border-border",
-        containerClassName // Allows custom class for container if needed (e.g., widget specific)
-        )}>
-      <div
-        className={cn(
-          'p-4 border-b border-border flex items-center justify-between',
-          headerClassName
-        )}
-        style={accentColor ? { backgroundColor: accentColor, color: '#fff' } : undefined}
-      >
-        <h2 className="text-xl font-semibold font-headline">
-          {title}
-        </h2>
-        {headerExtras}
-      </div>
-      
-      <ScrollArea className="flex-1 p-4" ref={scrollAreaRef}>
-        <div ref={viewportRef} className="space-y-2">
-         {messages.map((msg) => (
-            <ChatMessage key={msg.id} message={msg} />
-          ))}
-          {isLoading && (
-            <div className="flex items-center space-x-2 p-2 text-muted-foreground">
-              <Bot className="w-5 h-5 animate-pulse" />
-              <span>{title} is typing...</span>
-            </div>
-          )}
-        </div>
-      </ScrollArea>
-
-      <div className="p-4 border-t border-border bg-background/50 rounded-b-lg">
-        <form onSubmit={handleSubmit} className="flex items-center space-x-3">
-          <Input
-            type="text"
-            value={inputValue}
-            onChange={(e) => setInputValue(e.target.value)}
-            placeholder="Type your message..."
-            disabled={isLoading}
-            className="flex-1 !bg-white text-black focus:ring-primary focus:border-primary"
-            aria-label="Chat input"
-          />
-          <Button type="submit" disabled={isLoading || !inputValue.trim()} size="icon" aria-label="Send message">
-            <Send className="w-5 h-5" />
-          </Button>
-        </form>
-      </div>
-    </div>
+    <ChatUIWrapper
+      messages={messages}
+      isLoading={isLoading}
+      onSend={sendMessage}
+      inputValue={inputValue}
+      onInputChange={setInputValue}
+      containerClassName={containerClassName}
+      headerClassName={headerClassName}
+      headerExtras={headerExtras}
+      title={title}
+      accentColor={accentColor}
+    />
   );
 }

--- a/frontend/components/chatbot/ChatUIWrapper.tsx
+++ b/frontend/components/chatbot/ChatUIWrapper.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import React, { useEffect, useRef } from 'react';
+import type { Message } from '@/frontend/hooks/useChat';
+import { Button } from '@/frontend/components/ui/button';
+import { Input } from '@/frontend/components/ui/input';
+import { ScrollArea } from '@/frontend/components/ui/scroll-area';
+import { Avatar, AvatarFallback, AvatarImage } from '@/frontend/components/ui/avatar';
+import { Send, User, Bot, AlertTriangle, Headphones } from 'lucide-react';
+import { format } from 'date-fns';
+import { cn } from '@/frontend/lib/utils';
+
+function ChatMessage({ message }: { message: Message }) {
+  const isUser = message.role === 'user';
+  const isAssistant = message.role === 'assistant';
+  const isAgent = message.role === 'agent';
+  const isSystem = message.role === 'system';
+
+  return (
+    <div
+      className={cn(
+        'flex items-end space-x-3 py-3 px-1',
+        isUser ? 'justify-end' : 'justify-start'
+      )}
+    >
+      {!isUser && (
+        <Avatar className="h-8 w-8 shrink-0">
+          <AvatarImage
+            src={isAssistant ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K' : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'}
+            data-ai-hint="bot avatar"
+          />
+          <AvatarFallback>
+            {isAssistant ? <Bot size={18}/> : isAgent ? <Headphones size={18}/> : <AlertTriangle size={18}/>}
+          </AvatarFallback>
+        </Avatar>
+      )}
+      <div
+        className={cn(
+          'max-w-xs md:max-w-md lg:max-w-lg rounded-xl px-4 py-3 shadow-md',
+          isUser ? 'bg-primary text-primary-foreground rounded-br-none' : '',
+          isAssistant
+            ? 'bg-card text-card-foreground rounded-bl-none border border-border'
+            : isAgent
+            ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
+            : '',
+          isSystem ? 'bg-destructive/10 text-destructive-foreground border border-destructive/30 rounded-bl-none' : ''
+        )}
+      >
+        <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+        <p className={cn(
+             'text-xs mt-1.5',
+             isUser ? 'text-primary-foreground/70 text-right' : 'text-muted-foreground text-left'
+           )}>
+          {format(message.timestamp, 'p')}
+        </p>
+      </div>
+      {isUser && (
+        <Avatar className="h-8 w-8 shrink-0">
+          <AvatarImage src="https://placehold.co/40x40/8cb0eA/1A202C.png?text=U" data-ai-hint="user avatar" />
+          <AvatarFallback><User size={18}/></AvatarFallback>
+        </Avatar>
+      )}
+    </div>
+  );
+}
+
+export interface ChatUIWrapperProps {
+  messages: Message[];
+  isLoading: boolean;
+  onSend: (message: string) => void;
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  containerClassName?: string;
+  headerClassName?: string;
+  headerExtras?: React.ReactNode;
+  title?: string;
+  accentColor?: string;
+}
+
+export default function ChatUIWrapper({
+  messages,
+  isLoading,
+  onSend,
+  inputValue,
+  onInputChange,
+  containerClassName,
+  headerClassName,
+  headerExtras,
+  title = 'Kommander.ai Chat',
+  accentColor,
+}: ChatUIWrapperProps) {
+  const scrollAreaRef = useRef<HTMLDivElement>(null);
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (viewportRef.current) {
+      viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight, behavior: 'smooth' });
+    }
+  }, [messages]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (inputValue.trim()) {
+      onSend(inputValue);
+      onInputChange('');
+    }
+  };
+
+  return (
+    <div className={cn(
+        'flex flex-col h-full w-full bg-card shadow-xl rounded-lg border border-border',
+        containerClassName
+        )}>
+      <div
+        className={cn(
+          'p-4 border-b border-border flex items-center justify-between',
+          headerClassName
+        )}
+        style={accentColor ? { backgroundColor: accentColor, color: '#fff' } : undefined}
+      >
+        <h2 className="text-xl font-semibold font-headline">
+          {title}
+        </h2>
+        {headerExtras}
+      </div>
+
+      <ScrollArea className="flex-1 p-4" ref={scrollAreaRef}>
+        <div ref={viewportRef} className="space-y-2">
+         {messages.map((msg) => (
+            <ChatMessage key={msg.id} message={msg} />
+          ))}
+          {isLoading && (
+            <div className="flex items-center space-x-2 p-2 text-muted-foreground">
+              <Bot className="w-5 h-5 animate-pulse" />
+              <span>{title} is typing...</span>
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      <div className="p-4 border-t border-border bg-background/50 rounded-b-lg">
+        <form onSubmit={handleSubmit} className="flex items-center space-x-3">
+          <Input
+            type="text"
+            value={inputValue}
+            onChange={(e) => onInputChange(e.target.value)}
+            placeholder="Type your message..."
+            disabled={isLoading}
+            className="flex-1 !bg-white text-black focus:ring-primary focus:border-primary"
+            aria-label="Chat input"
+          />
+          <Button type="submit" disabled={isLoading || !inputValue.trim()} size="icon" aria-label="Send message">
+            <Send className="w-5 h-5" />
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/components/chatbot/ChatbotWidget.tsx
+++ b/frontend/components/chatbot/ChatbotWidget.tsx
@@ -1,17 +1,13 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { Send, Bot, User, X, Headphones } from 'lucide-react';
+import { X } from 'lucide-react';
 import { Badge } from '@/frontend/components/ui/badge';
 import { format } from 'date-fns';
 import { it } from 'date-fns/locale';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useWidgetChat } from '@/frontend/hooks/useWidgetChat';
-import { Button } from '@/frontend/components/ui/button';
-import { Input } from '@/frontend/components/ui/input';
-import { ScrollArea } from '@/frontend/components/ui/scroll-area';
-import { Avatar, AvatarFallback, AvatarImage } from '@/frontend/components/ui/avatar';
-import { cn } from '@/frontend/lib/utils';
+import ChatUIWrapper from '@/frontend/components/chatbot/ChatUIWrapper';
 
 interface ChatbotWidgetProps {
   userId: string;
@@ -22,7 +18,6 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
   const { messages, isLoading, sendMessage, addMessage, handledBy } = useWidgetChat(userId);
   const prevHandledBy = useRef<'bot' | 'agent'>('bot');
   const [inputValue, setInputValue] = useState('');
-  const viewportRef = useRef<HTMLDivElement>(null);
   const [botName, setBotName] = useState('Kommander.ai');
   const [botColor, setBotColor] = useState('#1E3A8A');
 
@@ -36,11 +31,6 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
       .catch(() => {});
   }, [userId]);
 
-  useEffect(() => {
-    if (viewportRef.current) {
-      viewportRef.current.scrollTo({ top: viewportRef.current.scrollHeight });
-    }
-  }, [messages]);
 
   useEffect(() => {
     if (handledBy === 'agent' && prevHandledBy.current !== 'agent') {
@@ -58,12 +48,6 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
 
   const currentDate = format(new Date(), 'dd MMM yyyy', { locale: it });
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!inputValue.trim()) return;
-    sendMessage(inputValue);
-    setInputValue('');
-  };
 
   return (
     <>
@@ -84,104 +68,28 @@ export default function ChatbotWidget({ userId }: ChatbotWidgetProps) {
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 20, scale: 0.95 }}
             transition={{ duration: 0.2 }}
-            className="fixed inset-0 sm:bottom-20 sm:right-4 sm:inset-auto z-50 flex w-full h-full sm:w-[400px] sm:h-[600px] flex-col bg-card border border-border rounded-none sm:rounded-lg shadow-xl"
+            className="fixed inset-0 sm:bottom-20 sm:right-4 sm:inset-auto z-50 w-full h-full sm:w-[400px] sm:h-[600px]"
           >
-            <div className="px-4 py-3 flex items-center justify-between rounded-t-lg text-white" style={{ backgroundColor: botColor }}>
-              <span className="font-semibold">{botName} – Trial</span>
-              <div className="flex items-center gap-2">
-                <Badge className="bg-green-600 text-white border-none">Online</Badge>
-                <span className="text-sm">{currentDate}</span>
-                <button onClick={() => setOpen(false)} aria-label="Close" className="ml-2">
-                  <X className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-            <ScrollArea className="flex-1 p-4">
-              <div ref={viewportRef} className="space-y-2">
-                {messages.map((msg) => (
-                  <div
-                    key={msg.id}
-                    className={cn(
-                      'flex items-end space-x-3 py-3 px-1',
-                      msg.role === 'user' ? 'justify-end' : 'justify-start',
-                    )}
-                  >
-                    {msg.role !== 'user' && (
-                      <Avatar className="h-8 w-8 shrink-0">
-                        <AvatarImage
-                          src={
-                            msg.role === 'assistant'
-                              ? 'https://placehold.co/40x40/1a56db/FFFFFF.png?text=K'
-                              : 'https://placehold.co/40x40/444/FFFFFF.png?text=A'
-                          }
-                        />
-                        <AvatarFallback>
-                          {msg.role === 'assistant' ? <Bot size={18} /> : <Headphones size={18} />}
-                        </AvatarFallback>
-                      </Avatar>
-                    )}
-                    <div
-                      className={cn(
-                        'max-w-[65%] rounded-lg px-3 py-2 shadow-md text-sm',
-                        msg.role === 'user'
-                          ? 'text-white rounded-br-none'
-                          : msg.role === 'agent'
-                          ? 'bg-accent text-accent-foreground rounded-bl-none border border-border'
-                          : 'bg-card text-card-foreground rounded-bl-none border border-border',
-                      )}
-                      style={msg.role === 'user' ? { backgroundColor: botColor } : undefined}
-                    >
-                      <p className="text-sm whitespace-pre-wrap">{msg.content}</p>
-                      <p
-                        className={cn(
-                          'text-xs mt-1.5',
-                          msg.role === 'user'
-                            ? 'text-primary-foreground/70 text-right'
-                            : 'text-muted-foreground text-left',
-                        )}
-                      >
-                        {format(msg.timestamp, 'p')}
-                      </p>
-                    </div>
-                    {msg.role === 'user' && (
-                      <Avatar className="h-8 w-8 shrink-0">
-                        <AvatarImage src="https://placehold.co/40x40/8cb0ea/1A202C.png?text=U" />
-                        <AvatarFallback>
-                          <User size={18} />
-                        </AvatarFallback>
-                      </Avatar>
-                    )}
-                  </div>
-                ))}
-                {isLoading && (
-                  <div className="text-muted-foreground text-sm flex items-center space-x-2">
-                    <Bot className="w-4 h-4 animate-pulse" />
-                    <span>{botName} sta scrivendo...</span>
-                  </div>
-                )}
-              </div>
-            </ScrollArea>
-            <form
-              onSubmit={handleSubmit}
-              className="p-4 border-t border-border bg-white rounded-b-2xl flex items-center space-x-3"
-            >
-              <Input
-                value={inputValue}
-                onChange={(e) => setInputValue(e.target.value)}
-                placeholder="Scrivi qui…"
-                disabled={isLoading}
-                className="flex-1 !bg-white text-black rounded-xl focus:ring-primary focus:border-primary"
-              />
-              <Button
-                type="submit"
-                size="icon"
-                disabled={isLoading || !inputValue.trim()}
-                aria-label="Invia"
-                className="rounded-full"
-              >
-                <Send className="w-4 h-4" />
-              </Button>
-            </form>
+            <ChatUIWrapper
+              messages={messages}
+              isLoading={isLoading}
+              onSend={sendMessage}
+              inputValue={inputValue}
+              onInputChange={setInputValue}
+              containerClassName="flex flex-col h-full w-full bg-card border border-border rounded-none sm:rounded-lg shadow-xl"
+              headerClassName="px-4 py-3 flex items-center justify-between rounded-t-lg text-white"
+              headerExtras={(
+                <div className="flex items-center gap-2">
+                  <Badge className="bg-green-600 text-white border-none">Online</Badge>
+                  <span className="text-sm">{currentDate}</span>
+                  <button onClick={() => setOpen(false)} aria-label="Close" className="ml-2">
+                    <X className="w-4 h-4" />
+                  </button>
+                </div>
+              )}
+              title={`${botName} – Trial`}
+              accentColor={botColor}
+            />
           </motion.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
## Summary
- extract message list and input form into `ChatUIWrapper`
- simplify `ChatUI` by reusing new wrapper
- update `ChatbotWidget` to reuse wrapper as well

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685ea26df418832691440a856c7fe899