### PR TITLE
Fix dark mode text visibility

### DIFF
--- a/frontend/components/conversations/ConversationsClient.tsx
+++ b/frontend/components/conversations/ConversationsClient.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/frontend/lib/utils';
 import { format } from 'date-fns';
 import { MoreVertical, UserCircle } from 'lucide-react';
 import AgentControlBar from './AgentControlBar';
+import { Input } from '@/frontend/components/ui/input';
 
 export interface ConversationMessageDisplay {
   role: 'user' | 'assistant' | 'agent';
@@ -199,7 +200,11 @@ export default function ConversationsClient({ conversations: initial }: Props) {
                 }}
                 className="p-2 border-t flex gap-2"
               >
-                <input name="agentMsg" className="flex-1 border rounded px-2 py-1" placeholder="Scrivi una risposta" />
+                <Input
+                  name="agentMsg"
+                  className="flex-1 h-8 px-2 py-1 bg-background text-foreground placeholder:text-muted-foreground"
+                  placeholder="Scrivi una risposta"
+                />
                 <button type="submit" className="px-3 py-1 rounded bg-primary text-primary-foreground">Invia</button>
               </form>
             )}

--- a/frontend/components/ui/input.tsx
+++ b/frontend/components/ui/input.tsx
@@ -13,7 +13,7 @@ type InputProps = React.ComponentProps<"input"> & {
 const Input = React.forwardRef<HTMLInputElement | HTMLTextAreaElement, InputProps>(
   ({ className, type, as = "input", rows, ...props }, ref) => {
     const Comp = as;
-    const commonClasses = "flex w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm";
+    const commonClasses = "flex w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm text-foreground";
 
     if (Comp === "textarea") {
       return (


### PR DESCRIPTION
## Summary
- ensure Input component text color uses the foreground variable
- apply styled Input in conversation agent reply form

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_685ed0e519cc8326ab2c016a5af94118