### PR TITLE
Fix widget chatbot issues

### DIFF
--- a/public/chatbot.css
+++ b/public/chatbot.css
@@ -44,7 +44,7 @@ body {
   bottom: 16px;
   right: 16px;
   z-index: 2147483647;
-  background: linear-gradient(to right, #6a11cb 0%, #2575fc 100%);
+  background: linear-gradient(to right, var(--kommander-primary-color) 0%, var(--kommander-secondary-color) 100%);
   color: var(--kommander-text-color-light);
   border-radius: 9999px;
   width: 56px; /* Slightly larger */
@@ -167,15 +167,16 @@ body {
 }
 
 .kommander-close, .kommander-toggle-dark-mode {
-  background: none;
+  background: rgba(255, 255, 255, 0.2);
   border: none;
   color: var(--kommander-text-color-light);
   cursor: pointer;
-  font-size: 24px;
+  font-size: 20px;
   line-height: 1;
   padding: 0;
-  width: 24px;
-  height: 24px;
+  width: 28px;
+  height: 28px;
+  border-radius: 9999px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -192,8 +193,8 @@ body {
 .kommander-messages {
   flex: 1;
   overflow-y: auto;
-  padding: 16px;
-  font-size: 14px;
+  padding: 12px;
+  font-size: 12px;
   background-color: var(--kommander-bg-light);
   color: var(--kommander-text-color-dark);
 }
@@ -233,6 +234,24 @@ body {
   justify-content: flex-start;
 }
 
+.kommander-message-wrap {
+  display: flex;
+  flex-direction: column;
+}
+
+.kommander-row-user .kommander-message-wrap {
+  align-items: flex-end;
+}
+
+.kommander-row-assistant .kommander-message-wrap,
+.kommander-row-agent .kommander-message-wrap {
+  align-items: flex-start;
+}
+
+.kommander-row-agent {
+  justify-content: flex-start;
+}
+
 .kommander-avatar {
   width: 36px; /* Slightly larger avatar */
   height: 36px;
@@ -243,8 +262,8 @@ body {
 
 .kommander-msg {
   max-width: 75%; /* Allow messages to take up more width */
-  padding: 12px 16px; /* More padding */
-  border-radius: 18px; /* Softer rounded corners */
+  padding: 8px 12px;
+  border-radius: 14px;
   box-shadow: 0 4px 10px var(--kommander-message-shadow); /* More pronounced shadow */
   border: 1px solid transparent; /* Base border */
   word-wrap: break-word;
@@ -268,12 +287,27 @@ body {
   margin-left: 0; /* Ensure no extra margin */
 }
 
+.kommander-agent {
+  background: var(--kommander-assistant-message-bg);
+  color: var(--kommander-text-color-dark);
+  border: 1px solid var(--kommander-assistant-message-border);
+  border-bottom-left-radius: 4px;
+  margin-left: 0;
+}
+
 .kommander-user p {
   color: var(--kommander-text-color-light) !important;
+  font-size: 12px;
 }
 
 .kommander-assistant p {
   color: var(--kommander-text-color-dark);
+  font-size: 12px;
+}
+
+.kommander-agent p {
+  color: var(--kommander-text-color-dark);
+  font-size: 12px;
 }
 
 .kommander-time {
@@ -285,6 +319,10 @@ body {
 }
 
 .kommander-row-assistant .kommander-time {
+  text-align: left;
+}
+
+.kommander-row-agent .kommander-time {
   text-align: left;
 }
 
@@ -343,6 +381,80 @@ body {
   cursor: pointer;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.kommander-restart {
+  background: var(--kommander-border-color);
+  color: var(--kommander-text-color-dark);
+  border: none;
+  border-radius: 9999px;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.kommander-restart:hover {
+  background: var(--kommander-secondary-color);
+  color: var(--kommander-text-color-light);
+}
+
+.kommander-restart svg {
+  width: 16px;
+  height: 16px;
+  fill: currentColor;
+}
+
+.kommander-modal-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.kommander-modal {
+  background: var(--kommander-bg-light);
+  color: var(--kommander-text-color-dark);
+  padding: 20px;
+  border-radius: 8px;
+  width: 90%;
+  max-width: 300px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.kommander-window.dark-mode .kommander-modal {
+  background: var(--kommander-bg-dark-message);
+  color: var(--kommander-text-color-light);
+}
+
+.kommander-modal-buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.kommander-modal-buttons button {
+  padding: 6px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.kommander-modal-confirm {
+  background: var(--kommander-primary-color);
+  color: var(--kommander-text-color-light);
+}
+
+.kommander-modal-cancel {
+  background: var(--kommander-border-color);
+  color: var(--kommander-text-color-dark);
 }
 
 .kommander-input button:hover {

--- a/public/chatbot.js
+++ b/public/chatbot.js
@@ -38,13 +38,16 @@
     const [handledBy, setHandledBy] = useState('bot');
     const [conversationId, setConversationId] = useState('');
     const [isTyping, setIsTyping] = useState(false);
+    const [botName, setBotName] = useState('Kommander.ai');
+    const [botColor, setBotColor] = useState('#1E3A8A');
     const [isDarkMode, setIsDarkMode] = useState(() => {
       try {
-        return localStorage.getItem('kommander_dark_mode') === 'true';
+        const stored = localStorage.getItem('kommander_dark_mode');
+        if (stored !== null) return stored === 'true';
       } catch (e) {
         console.error("Failed to read dark mode from localStorage", e);
-        return false;
       }
+      return window.matchMedia('(prefers-color-scheme: dark)').matches;
     });
 
     const viewportRef = useRef(null);
@@ -52,6 +55,23 @@
     const lastTimestampRef = useRef('');
     const pollFnRef = useRef(null);
     const prevHandledBy = useRef('bot');
+    const lastSentTextRef = useRef('');
+    const isSendingRef = useRef(false);
+    const [showRestartConfirm, setShowRestartConfirm] = useState(false);
+
+    const restartConversation = () => {
+      const newId = `konv-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      conversationIdRef.current = newId;
+      setConversationId(newId);
+      localStorage.setItem(storageKey, newId);
+      setMessages([]);
+      lastTimestampRef.current = '';
+    };
+
+    const confirmRestart = () => {
+      restartConversation();
+      setShowRestartConfirm(false);
+    };
 
     const toggleDarkMode = () => {
       setIsDarkMode(prevMode => {
@@ -69,10 +89,33 @@
       return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     }
 
-    function addMessage(role, text) {
+    function addMessage(role, text, updateTimestamp = true) {
       setMessages((prev) => [...prev, { role, text, time: formatTime() }]);
-      lastTimestampRef.current = new Date().toISOString();
+      if (updateTimestamp) {
+        lastTimestampRef.current = new Date().toISOString();
+      }
     }
+
+    useEffect(() => {
+      fetch(`${ORIGIN}/api/settings/${userId}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (!data) return;
+          if (data.name) setBotName(data.name);
+          if (data.color) {
+            setBotColor(data.color);
+            document.documentElement.style.setProperty(
+              '--kommander-primary-color',
+              data.color,
+            );
+            document.documentElement.style.setProperty(
+              '--kommander-secondary-color',
+              data.color,
+            );
+          }
+        })
+        .catch(() => {});
+    }, [userId]);
 
     const currentDate = new Date().toLocaleDateString('it-IT', {
       day: '2-digit',
@@ -88,9 +131,9 @@
 
     useEffect(() => {
       if (open && messages.length === 0) {
-        addMessage('assistant', 'Ciao, sono Kommander.ai! Come posso aiutarti oggi?');
+        addMessage('assistant', `Ciao, sono ${botName}! Come posso aiutarti oggi?`);
       }
-    }, [open]);
+    }, [open, botName]);
 
     const storageKey = `kommander_conversation_${userId}`;
 
@@ -125,7 +168,7 @@
       }
     };
 
-    const poll = async () => {
+    const poll = async (skipUserDup = false) => {
       const id = conversationIdRef.current;
       if (!id) return;
       try {
@@ -135,11 +178,14 @@
         if (res.ok) {
           const data = await res.json();
           setHandledBy(data.handledBy || 'bot');
-          const newMsgs = (data.messages || []).map((m) => ({
+          let newMsgs = (data.messages || []).map((m) => ({
             role: m.role,
             text: m.text,
             time: new Date(m.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
           }));
+          if (skipUserDup && newMsgs.length && newMsgs[0].role === 'user' && newMsgs[0].text === lastSentTextRef.current) {
+            newMsgs = newMsgs.slice(1);
+          }
           if (newMsgs.length) {
             lastTimestampRef.current = data.messages[data.messages.length - 1].timestamp;
             setMessages((prev) => [...prev, ...newMsgs]);
@@ -174,9 +220,11 @@
 
     const sendMessage = async () => {
       const text = input.trim();
-      if (!text) return;
+      if (!text || isSendingRef.current) return;
+      isSendingRef.current = true;
 
-      addMessage('user', text);
+      addMessage('user', text, false);
+      lastSentTextRef.current = text;
       setIsTyping(true); // Show typing indicator
 
       const isHumanRequest = text.toLowerCase().includes('operatore umano');
@@ -230,7 +278,8 @@
         console.error("Failed to send message:", err);
       } finally {
         setIsTyping(false); // Hide typing indicator
-        if (pollFnRef.current) pollFnRef.current(); // Manual poll after sending message
+        isSendingRef.current = false;
+        if (pollFnRef.current) pollFnRef.current(true); // Manual poll after sending message
       }
     };
 
@@ -267,7 +316,7 @@
           React.createElement(
             'div',
             { className: 'kommander-header' },
-            React.createElement('span', { className: 'font-semibold' }, 'Kommander.ai – Trial'),
+            React.createElement('span', { className: 'font-semibold' }, botName + ' – Trial'),
             React.createElement(
               'div',
               { className: 'kommander-header-right' },
@@ -325,10 +374,14 @@
                   }),
                 React.createElement(
                   'div',
-                  {
-                    className: `kommander-msg kommander-${m.role}`,
-                  },
-                  React.createElement('p', null, m.text),
+                  { className: 'kommander-message-wrap' },
+                  React.createElement(
+                    'div',
+                    {
+                      className: `kommander-msg kommander-${m.role}`,
+                    },
+                    React.createElement('p', null, m.text),
+                  ),
                   React.createElement('p', { className: 'kommander-time' }, m.time),
                 ),
                 m.role === 'user' &&
@@ -363,6 +416,15 @@
               },
               className: 'kommander-input',
             },
+            React.createElement(
+              'button',
+              { type: 'button', className: 'kommander-restart', onClick: () => setShowRestartConfirm(true), disabled: isTyping, 'aria-label': 'Ricomincia' },
+              React.createElement(
+                'svg',
+                { xmlns: 'http://www.w3.org/2000/svg', viewBox: '0 0 1920 1920', width: '16', height: '16', fill: 'currentColor' },
+                React.createElement('path', { d: 'M960 0v112.941c467.125 0 847.059 379.934 847.059 847.059 0 467.125-379.934 847.059-847.059 847.059-467.125 0-847.059-379.934-847.059-847.059 0-267.106 126.607-515.915 338.824-675.727v393.374h112.94V112.941H0v112.941h342.89C127.058 407.38 0 674.711 0 960c0 529.355 430.645 960 960 960s960-430.645 960-960S1489.355 0 960 0' })
+              )
+            ),
             React.createElement('input', {
               value: input,
               onChange: (e) => setInput(e.target.value),
@@ -394,6 +456,34 @@
               )
             ),
           ),
+          showRestartConfirm &&
+            React.createElement(
+              'div',
+              { className: 'kommander-modal-overlay' },
+              React.createElement(
+                'div',
+                { className: 'kommander-modal' },
+                React.createElement(
+                  'p',
+                  null,
+                  'Ricominciare la conversazione?'
+                ),
+                React.createElement(
+                  'div',
+                  { className: 'kommander-modal-buttons' },
+                  React.createElement(
+                    'button',
+                    { className: 'kommander-modal-confirm', onClick: confirmRestart },
+                    'S\u00ec'
+                  ),
+                  React.createElement(
+                    'button',
+                    { className: 'kommander-modal-cancel', onClick: () => setShowRestartConfirm(false) },
+                    'No'
+                  )
+                )
+              )
+            ),
         ),
     );
   }


### PR DESCRIPTION
## Summary
- adjust dark mode initialization and apply settings color to header
- prevent duplicate sends and show restart confirmation inside the widget
- display timestamps outside message bubbles and support agent styling
- add restart button icon and modal styles

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68616d86c7c483269956752a1af312cb